### PR TITLE
Worked out FAQ container edge cases.

### DIFF
--- a/src/containers/Products/Reduce/FAQ/Faq.js
+++ b/src/containers/Products/Reduce/FAQ/Faq.js
@@ -11,8 +11,22 @@ export default function Faq() {
 
   const handleClick = id => {
     const prevFaqlist = faqlist
-    prevFaqlist[id].expanded = !prevFaqlist[id].expanded
-    setFaqlist([...prevFaqlist])
+
+    if (faqlist[id].expanded === false) {
+      /* Clicking on differnet accordion expands it, while hides the rest */
+      prevFaqlist.map((element, key) => {
+        element.expanded = false
+      })
+      prevFaqlist[id].expanded = !prevFaqlist[id].expanded
+      setFaqlist([...prevFaqlist])
+    } else {
+      /* Clicking on same accordion sets everything back to its false aka collapsed. */
+      prevFaqlist.map((element, key) => {
+        element.expanded = false
+      })
+
+      setFaqlist([...prevFaqlist])
+    }
   }
 
   return (

--- a/src/containers/Products/Reduce/FAQ/Faq.js
+++ b/src/containers/Products/Reduce/FAQ/Faq.js
@@ -24,7 +24,6 @@ export default function Faq() {
       prevFaqlist.map((element, key) => {
         element.expanded = false
       })
-
       setFaqlist([...prevFaqlist])
     }
   }


### PR DESCRIPTION
- Clicking on a different accordion expands it and hides the rest.
- Clicking on an already expanded accordion collapses it and collapses the rest.
- Makes sure that the FAQ container list doesn't get too long and pushes down the rest of the page.

Removed switch statements and made the handleClick event handler method dynamic.